### PR TITLE
feat(filters): ts-belt + zod url sync and pagination refactor

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
+        "@mobily/ts-belt": "^3.13.1",
         "@tailwindcss/vite": "^4.1.4",
         "@tanstack/react-table": "^8.21.3",
         "axios": "^1.8.4",
@@ -1005,6 +1006,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mobily/ts-belt": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@mobily/ts-belt/-/ts-belt-3.13.1.tgz",
+      "integrity": "sha512-K5KqIhPI/EoCTbA6CGbrenM9s41OouyK8A03fGJJcla/zKucsgLbz8HNbeseoLarRPgyWJsUyCYqFhI7t3Ra9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.*"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2151,9 +2151,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2329,9 +2329,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
+    "@mobily/ts-belt": "^3.13.1",
     "@tailwindcss/vite": "^4.1.4",
     "@tanstack/react-table": "^8.21.3",
     "axios": "^1.8.4",

--- a/client/src/api/trackService.ts
+++ b/client/src/api/trackService.ts
@@ -2,8 +2,12 @@ import type { Result } from "neverthrow";
 import { BaseService } from "./baseService";
 import type { IHttpClient } from "./httpClient";
 import type { AppError } from "./errors";
-import type { Track, Paginated, FetchTracksOptions } from "@/types";
-import type { TrackFormData } from "@/schemas";
+import type { Track, Paginated } from "@/types";
+import {
+  trackQuerySchema,
+  type TrackFormData,
+  type TrackQueryInput,
+} from "@/schemas";
 
 /**
  * TrackService — thin wrapper over /api/tracks endpoints.
@@ -26,12 +30,12 @@ export class TrackService extends BaseService<Track, TrackFormData> {
    * GET /tracks (paginated)
    */
   fetchTracks(
-    opts: FetchTracksOptions = {},
+    opts: TrackQueryInput = {},
     signal?: AbortSignal
   ): Promise<Result<Paginated<Track>, AppError>> {
-    const { page = 1, limit = 10, ...filters } = opts;
+    const params = trackQuerySchema.parse(opts);
     return this.http.get<Paginated<Track>>(`/api/${TrackService.resource}`, {
-      params: { page, limit, ...filters },
+      params,
       signal,
     });
   }

--- a/client/src/components/TrackTable/PaginationControls.tsx
+++ b/client/src/components/TrackTable/PaginationControls.tsx
@@ -4,16 +4,14 @@ interface Props {
   page: number;
   totalPages: number;
   limit: number;
-  setPage: (p: number) => void;
-  setLimit: (l: number) => void;
+  patch(q: Record<string, string | number | undefined>): void;
 }
 
 export const PaginationControls: React.FC<Props> = ({
   page,
   totalPages,
   limit,
-  setPage,
-  setLimit,
+  patch,
 }) => (
   <div
     className="flex items-center justify-end flex-wrap gap-4 mt-4"
@@ -21,7 +19,7 @@ export const PaginationControls: React.FC<Props> = ({
   >
     <button
       className="btn btn-sm"
-      onClick={() => setPage(page - 1)}
+      onClick={() => patch({ page: page - 1 })}
       disabled={page <= 1}
       data-testid="pagination-prev"
     >
@@ -34,7 +32,7 @@ export const PaginationControls: React.FC<Props> = ({
 
     <button
       className="btn btn-sm"
-      onClick={() => setPage(page + 1)}
+      onClick={() => patch({ page: page + 1 })}
       disabled={page >= totalPages}
       data-testid="pagination-next"
     >
@@ -44,10 +42,7 @@ export const PaginationControls: React.FC<Props> = ({
     <select
       className="select select-bordered select-sm"
       value={limit}
-      onChange={(e) => {
-        setLimit(Number(e.target.value));
-        setPage(1);
-      }}
+      onChange={(e) => patch({ limit: Number(e.target.value), page: 1 })}
     >
       {[5, 10, 20].map((n) => (
         <option key={n} value={n}>

--- a/client/src/components/TrackTable/index.tsx
+++ b/client/src/components/TrackTable/index.tsx
@@ -17,13 +17,10 @@ export interface TrackTableProps {
   data: Track[];
   sort: keyof Track;
   order: "asc" | "desc";
-  setSort(v: keyof Track): void;
-  setOrder(v: "asc" | "desc"): void;
   page: number;
   totalPages: number;
   limit: number;
-  setPage(p: number): void;
-  setLimit(l: number): void;
+  patch(q: Record<string, string | number | undefined>): void;
   onEdit(track: Track): void;
   onDelete(track: Track): void;
   onUploadClick(track: Track): void;
@@ -35,13 +32,10 @@ export const TrackTable: React.FC<TrackTableProps> = ({
   data,
   sort,
   order,
-  setSort,
-  setOrder,
   page,
   totalPages,
   limit,
-  setPage,
-  setLimit,
+  patch,
   onEdit,
   onDelete,
   onUploadClick,
@@ -62,10 +56,9 @@ export const TrackTable: React.FC<TrackTableProps> = ({
   useEffect(() => {
     const first = sorting[0];
     if (first && first.id !== "genres") {
-      setSort(first.id as keyof Track);
-      setOrder(first.desc ? "desc" : "asc");
+      patch({ sort: first.id, order: first.desc ? "desc" : "asc" });
     }
-  }, [sorting, setSort, setOrder]);
+  }, [sorting, patch]);
 
   const table = useReactTable<Track>({
     data,
@@ -154,8 +147,7 @@ export const TrackTable: React.FC<TrackTableProps> = ({
         page={page}
         totalPages={totalPages}
         limit={limit}
-        setPage={setPage}
-        setLimit={setLimit}
+        patch={patch}
       />
     </>
   );

--- a/client/src/components/common/SearchInput/index.tsx
+++ b/client/src/components/common/SearchInput/index.tsx
@@ -1,4 +1,9 @@
-import React, { useState, useEffect, type InputHTMLAttributes } from "react";
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  type InputHTMLAttributes,
+} from "react";
 import { Search } from "lucide-react";
 
 type NativeInputProps = Omit<
@@ -28,10 +33,18 @@ export const SearchInput: React.FC<SearchInputProps> = ({
     setValue(initialValue);
   }, [initialValue]);
 
+  const didMountRef = useRef(false);
+
   useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    if (value === initialValue) return;
+
     const handler = setTimeout(() => onChange(value), debounce);
     return () => clearTimeout(handler);
-  }, [value, debounce, onChange]);
+  }, [value, initialValue, debounce, onChange]);
 
   return (
     <fieldset className="fieldset w-full sm:w-auto">

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -1,1 +1,1 @@
-export { TRACK_QUERY_DEFAULTS } from "./trackQuery";
+export { TRACK_QUERY_DEFAULTS, LIMIT_SET, type LimitValue } from "./trackQuery";

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -1,0 +1,1 @@
+export { TRACK_QUERY_DEFAULTS } from "./trackQuery";

--- a/client/src/constants/trackQuery.ts
+++ b/client/src/constants/trackQuery.ts
@@ -1,8 +1,12 @@
-import type { SortKey } from "@/schemas";
+export const LIMIT_SET = [5, 10, 20] as const;
+export type LimitValue = (typeof LIMIT_SET)[number];
 
 export const TRACK_QUERY_DEFAULTS = {
   page: 1,
-  limit: 10,
-  sort: "title" as SortKey,
-  order: "asc" as const,
+  limit: 10 as LimitValue,
+  sort: "title",
+  order: "asc",
+  genre: "",
+  artist: "",
+  search: "",
 } as const;

--- a/client/src/constants/trackQuery.ts
+++ b/client/src/constants/trackQuery.ts
@@ -1,8 +1,8 @@
-import type { Track } from "@/types";
+import type { SortKey } from "@/schemas";
 
 export const TRACK_QUERY_DEFAULTS = {
   page: 1,
   limit: 10,
-  sort: "title" as keyof Track,
+  sort: "title" as SortKey,
   order: "asc" as const,
 } as const;

--- a/client/src/hooks/useTracks.ts
+++ b/client/src/hooks/useTracks.ts
@@ -2,28 +2,23 @@ import { useState, useEffect, useCallback } from "react";
 import { trackService } from "@/api";
 import type { Track, Meta } from "@/types";
 import type { AppError } from "@/api/errors";
+import { useTrackQuery } from "@/lib/useTrackQuery";
 
 /**
- * Fetch and control paged track data
+ * Fetch paginated tracks, params come from URL
  */
-export function useTracks(initialLimit = 10) {
+export function useTracks() {
+  const { page, limit, sort, order, genre, artist, search } = useTrackQuery();
+
   const [data, setData] = useState<Track[]>([]);
   const [meta, setMeta] = useState<Meta>({
     total: 0,
-    page: 1,
-    limit: initialLimit,
+    page,
+    limit,
     totalPages: 1,
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<AppError | null>(null);
-
-  const [page, setPage] = useState(1);
-  const [limit, setLimit] = useState(initialLimit);
-  const [sort, setSort] = useState<keyof Track>("title");
-  const [order, setOrder] = useState<"asc" | "desc">("asc");
-  const [genre, setGenre] = useState("");
-  const [artist, setArtist] = useState("");
-  const [search, setSearch] = useState("");
 
   const fetchData = useCallback(
     async (signal?: AbortSignal) => {
@@ -53,25 +48,5 @@ export function useTracks(initialLimit = 10) {
     return () => ctrl.abort();
   }, [fetchData]);
 
-  return {
-    data,
-    meta,
-    loading,
-    error,
-    page,
-    limit,
-    sort,
-    order,
-    genre,
-    artist,
-    search,
-    setPage,
-    setLimit,
-    setSort,
-    setOrder,
-    setGenre,
-    setArtist,
-    setSearch,
-    refetch: () => fetchData(),
-  };
+  return { data, meta, loading, error, refetch: fetchData };
 }

--- a/client/src/hooks/useTracks.ts
+++ b/client/src/hooks/useTracks.ts
@@ -2,13 +2,14 @@ import { useState, useEffect, useCallback } from "react";
 import { trackService } from "@/api";
 import type { Track, Meta } from "@/types";
 import type { AppError } from "@/api/errors";
-import { useTrackQuery } from "@/lib/useTrackQuery";
+import { useTrackQuery } from "@/lib";
 
 /**
  * Fetch paginated tracks, params come from URL
  */
 export function useTracks() {
-  const { page, limit, sort, order, genre, artist, search } = useTrackQuery();
+  const { query, patch } = useTrackQuery();
+  const { page, limit } = query;
 
   const [data, setData] = useState<Track[]>([]);
   const [meta, setMeta] = useState<Meta>({
@@ -23,10 +24,7 @@ export function useTracks() {
   const fetchData = useCallback(
     async (signal?: AbortSignal) => {
       setLoading(true);
-      const res = await trackService.fetchTracks(
-        { page, limit, sort, order, genre, artist, search },
-        signal
-      );
+      const res = await trackService.fetchTracks(query, signal);
 
       res.match(
         ({ data: list, meta: m }) => {
@@ -36,10 +34,9 @@ export function useTracks() {
         },
         (e) => setError(e)
       );
-
       setLoading(false);
     },
-    [page, limit, sort, order, genre, artist, search]
+    [query]
   );
 
   useEffect(() => {
@@ -48,5 +45,5 @@ export function useTracks() {
     return () => ctrl.abort();
   }, [fetchData]);
 
-  return { data, meta, loading, error, refetch: fetchData };
+  return { data, meta, loading, error, refetch: fetchData, patch };
 }

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -1,0 +1,8 @@
+import type { Track } from "@/types";
+
+export const TRACK_QUERY_DEFAULTS = {
+  page: 1,
+  limit: 10,
+  sort: "title" as keyof Track,
+  order: "asc" as const,
+} as const;

--- a/client/src/lib/index.ts
+++ b/client/src/lib/index.ts
@@ -1,0 +1,1 @@
+export { useTrackQuery } from "./useTrackQuery";

--- a/client/src/lib/parseSearchParams.ts
+++ b/client/src/lib/parseSearchParams.ts
@@ -1,0 +1,18 @@
+import { pipe, O, R } from "@mobily/ts-belt";
+import { trackQuerySchema, type TrackQueryParams } from "@/schemas";
+
+/**
+ * Parse URLSearchParams into TrackQueryParams or return an error message
+ */
+export const parseSearchParams = (
+  sp: URLSearchParams
+): R.Result<TrackQueryParams, string> =>
+  pipe(
+    O.fromExecution(() => Object.fromEntries(sp)),
+    O.toResult("failed to read URLSearchParams"),
+    R.flatMap((obj) =>
+      pipe(trackQuerySchema.safeParse(obj), (r) =>
+        r.success ? R.Ok(r.data) : R.Error(r.error.message)
+      )
+    )
+  );

--- a/client/src/lib/urlSearch.ts
+++ b/client/src/lib/urlSearch.ts
@@ -1,0 +1,19 @@
+import { TRACK_QUERY_DEFAULTS } from "@/constants";
+import type { TrackQueryParams } from "@/schemas";
+
+/**
+ * Serialise params, hiding defaults & empty values
+ */
+export const buildSearchParams = (
+  params: TrackQueryParams
+): URLSearchParams => {
+  const search = new URLSearchParams();
+  const defaults = TRACK_QUERY_DEFAULTS as Record<string, unknown>;
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === "" || value === defaults[key]) return;
+    search.set(key, String(value));
+  });
+
+  return search;
+};

--- a/client/src/lib/useTrackQuery.ts
+++ b/client/src/lib/useTrackQuery.ts
@@ -1,0 +1,40 @@
+import { useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+import type { Track } from "@/types";
+import { TRACK_QUERY_DEFAULTS } from "./constants";
+
+export function useTrackQuery() {
+  const [sp, setSp] = useSearchParams();
+
+  const num = (k: string, d: number) =>
+    Math.max(1, Number.parseInt(sp.get(k) ?? "", 10) || d);
+
+  const page = num("page", TRACK_QUERY_DEFAULTS.page);
+  const limit = num("limit", TRACK_QUERY_DEFAULTS.limit);
+  const sort = (sp.get("sort") as keyof Track) ?? TRACK_QUERY_DEFAULTS.sort;
+  const order =
+    (sp.get("order") as "asc" | "desc") ?? TRACK_QUERY_DEFAULTS.order;
+
+  const genre = sp.get("genre") ?? "";
+  const artist = sp.get("artist") ?? "";
+  const search = sp.get("search") ?? "";
+
+  const patch = useCallback(
+    (updates: Partial<Record<string, string | number | undefined>>) => {
+      const next = new URLSearchParams(window.location.search);
+
+      Object.entries(updates).forEach(([k, v]) => {
+        if (v == null || v === "") {
+          next.delete(k);
+        } else {
+          next.set(k, String(v));
+        }
+      });
+
+      setSp(next, { replace: true });
+    },
+    [setSp]
+  );
+
+  return { page, limit, sort, order, genre, artist, search, patch };
+}

--- a/client/src/lib/useTrackQuery.ts
+++ b/client/src/lib/useTrackQuery.ts
@@ -1,40 +1,32 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
-import type { Track } from "@/types";
-import { TRACK_QUERY_DEFAULTS } from "./constants";
+import { pipe, R } from "@mobily/ts-belt";
+import { TRACK_QUERY_DEFAULTS } from "@/constants";
+import type { TrackQueryParams } from "@/schemas";
+import { parseSearchParams } from "./parseSearchParams";
 
 export function useTrackQuery() {
-  const [sp, setSp] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const num = (k: string, d: number) =>
-    Math.max(1, Number.parseInt(sp.get(k) ?? "", 10) || d);
-
-  const page = num("page", TRACK_QUERY_DEFAULTS.page);
-  const limit = num("limit", TRACK_QUERY_DEFAULTS.limit);
-  const sort = (sp.get("sort") as keyof Track) ?? TRACK_QUERY_DEFAULTS.sort;
-  const order =
-    (sp.get("order") as "asc" | "desc") ?? TRACK_QUERY_DEFAULTS.order;
-
-  const genre = sp.get("genre") ?? "";
-  const artist = sp.get("artist") ?? "";
-  const search = sp.get("search") ?? "";
-
-  const patch = useCallback(
-    (updates: Partial<Record<string, string | number | undefined>>) => {
-      const next = new URLSearchParams(window.location.search);
-
-      Object.entries(updates).forEach(([k, v]) => {
-        if (v == null || v === "") {
-          next.delete(k);
-        } else {
-          next.set(k, String(v));
-        }
-      });
-
-      setSp(next, { replace: true });
-    },
-    [setSp]
+  const query: TrackQueryParams = useMemo(
+    () =>
+      pipe(
+        parseSearchParams(searchParams),
+        R.getWithDefault({ ...TRACK_QUERY_DEFAULTS } as TrackQueryParams)
+      ),
+    [searchParams]
   );
 
-  return { page, limit, sort, order, genre, artist, search, patch };
+  const patch = useCallback(
+    (updates: Partial<TrackQueryParams>) => {
+      const next = new URLSearchParams(searchParams);
+      Object.entries(updates).forEach(([k, v]) =>
+        v == null || v === "" ? next.delete(k) : next.set(k, String(v))
+      );
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams]
+  );
+
+  return { query, patch };
 }

--- a/client/src/pages/TracksPage/index.tsx
+++ b/client/src/pages/TracksPage/index.tsx
@@ -19,7 +19,9 @@ const TracksPage: React.FC = () => {
     data,
     meta: { totalPages },
     refetch: refetchTracks,
+    patch,
   } = useTracks();
+  const { query } = useTrackQuery();
   const {
     page,
     limit,
@@ -28,8 +30,7 @@ const TracksPage: React.FC = () => {
     genre: filterGenre,
     artist: filterArtist,
     search,
-    patch,
-  } = useTrackQuery();
+  } = query;
 
   const memoData = useMemo(() => data, [data]);
 
@@ -169,11 +170,11 @@ const TracksPage: React.FC = () => {
         <TrackToolbar
           artists={artists}
           genres={genres}
-          filterArtist={filterArtist}
+          filterArtist={filterArtist ?? ""}
           setFilterArtist={(v) => patch({ artist: v, page: 1 })}
-          filterGenre={filterGenre}
+          filterGenre={filterGenre ?? ""}
           setFilterGenre={(v) => patch({ genre: v, page: 1 })}
-          search={search}
+          search={search ?? ""}
           setSearch={(v) => patch({ search: v, page: 1 })}
         />
 

--- a/client/src/pages/TracksPage/index.tsx
+++ b/client/src/pages/TracksPage/index.tsx
@@ -12,32 +12,32 @@ import type { Track } from "@/types";
 import type { TrackFormData } from "@/schemas";
 import { trackService } from "@/api";
 import { extractErrorMessage, showToastMessage } from "@/helpers";
+import { useTrackQuery } from "@/lib";
 
 const TracksPage: React.FC = () => {
   const {
     data,
     meta: { totalPages },
-    page,
-    limit,
-    setPage,
-    setLimit,
-    sort,
-    order,
-    setSort,
-    setOrder,
-    genre: filterGenre,
-    setGenre: setFilterGenre,
-    artist: filterArtist,
-    setArtist: setFilterArtist,
-    search,
-    setSearch,
     refetch: refetchTracks,
   } = useTracks();
+  const {
+    page,
+    limit,
+    sort,
+    order,
+    genre: filterGenre,
+    artist: filterArtist,
+    search,
+    patch,
+  } = useTrackQuery();
+
   const memoData = useMemo(() => data, [data]);
 
   useEffect(() => {
-    if (page > totalPages) setPage(totalPages || 1);
-  }, [page, totalPages, setPage]);
+    if (page > totalPages && totalPages >= 1) {
+      patch({ page: totalPages });
+    }
+  }, [page, totalPages, patch]);
 
   const genres = useGenres();
   const artists = useArtists();
@@ -170,24 +170,21 @@ const TracksPage: React.FC = () => {
           artists={artists}
           genres={genres}
           filterArtist={filterArtist}
-          setFilterArtist={setFilterArtist}
+          setFilterArtist={(v) => patch({ artist: v, page: 1 })}
           filterGenre={filterGenre}
-          setFilterGenre={setFilterGenre}
+          setFilterGenre={(v) => patch({ genre: v, page: 1 })}
           search={search}
-          setSearch={setSearch}
+          setSearch={(v) => patch({ search: v, page: 1 })}
         />
 
         <TrackTable
           data={memoData}
           sort={sort}
           order={order}
-          setSort={setSort}
-          setOrder={setOrder}
           page={page}
           totalPages={totalPages}
           limit={limit}
-          setPage={setPage}
-          setLimit={setLimit}
+          patch={patch}
           onEdit={setEditingTrack}
           onDelete={setDeletingTrack}
           onUploadClick={setUploadingTrack}

--- a/client/src/schemas/index.ts
+++ b/client/src/schemas/index.ts
@@ -1,4 +1,4 @@
 export { trackFormSchema } from "./track";
 export type { TrackFormData } from "./track";
 export { trackQuerySchema, SortKeySchema } from "./trackQuery";
-export type { TrackQueryParams, SortKey } from "./trackQuery";
+export type { TrackQueryParams, TrackQueryInput, SortKey } from "./trackQuery";

--- a/client/src/schemas/index.ts
+++ b/client/src/schemas/index.ts
@@ -1,4 +1,8 @@
 export { trackFormSchema } from "./track";
 export type { TrackFormData } from "./track";
-export { trackQuerySchema, SortKeySchema } from "./trackQuery";
+export {
+  trackQuerySchema,
+  SortKeySchema,
+  SCHEMA_DEFAULT_QUERY,
+} from "./trackQuery";
 export type { TrackQueryParams, TrackQueryInput, SortKey } from "./trackQuery";

--- a/client/src/schemas/index.ts
+++ b/client/src/schemas/index.ts
@@ -1,2 +1,4 @@
 export { trackFormSchema } from "./track";
 export type { TrackFormData } from "./track";
+export { trackQuerySchema, SortKeySchema } from "./trackQuery";
+export type { TrackQueryParams, SortKey } from "./trackQuery";

--- a/client/src/schemas/trackQuery.ts
+++ b/client/src/schemas/trackQuery.ts
@@ -20,3 +20,4 @@ export const trackQuerySchema = z.object({
 });
 
 export type TrackQueryParams = z.infer<typeof trackQuerySchema>;
+export type TrackQueryInput  = z.input<typeof trackQuerySchema>;

--- a/client/src/schemas/trackQuery.ts
+++ b/client/src/schemas/trackQuery.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { TRACK_QUERY_DEFAULTS } from "@/constants";
+
+export const SortKeySchema = z.enum([
+  "title",
+  "artist",
+  "album",
+  "genres",
+] as const);
+export type SortKey = z.infer<typeof SortKeySchema>;
+
+export const trackQuerySchema = z.object({
+  page: z.coerce.number().int().positive().default(TRACK_QUERY_DEFAULTS.page),
+  limit: z.coerce.number().int().positive().default(TRACK_QUERY_DEFAULTS.limit),
+  sort: SortKeySchema.default(TRACK_QUERY_DEFAULTS.sort),
+  order: z.enum(["asc", "desc"]).default(TRACK_QUERY_DEFAULTS.order),
+  genre: z.string().default(""),
+  artist: z.string().default(""),
+  search: z.string().default(""),
+});
+
+export type TrackQueryParams = z.infer<typeof trackQuerySchema>;

--- a/client/src/schemas/trackQuery.ts
+++ b/client/src/schemas/trackQuery.ts
@@ -1,23 +1,43 @@
 import { z } from "zod";
-import { TRACK_QUERY_DEFAULTS } from "@/constants";
+import { TRACK_QUERY_DEFAULTS, LIMIT_SET, type LimitValue } from "@/constants";
 
-export const SortKeySchema = z.enum([
-  "title",
-  "artist",
-  "album",
-  "genres",
-] as const);
+export const SortKeySchema = z.enum(["title", "artist", "album", "genres"]);
 export type SortKey = z.infer<typeof SortKeySchema>;
 
 export const trackQuerySchema = z.object({
-  page: z.coerce.number().int().positive().default(TRACK_QUERY_DEFAULTS.page),
-  limit: z.coerce.number().int().positive().default(TRACK_QUERY_DEFAULTS.limit),
+  page: z.coerce
+    .number()
+    .catch(TRACK_QUERY_DEFAULTS.page)
+    .transform((n) => (n < 1 ? 1 : n))
+    .default(TRACK_QUERY_DEFAULTS.page),
+
+  limit: z.coerce
+    .number()
+    .catch(TRACK_QUERY_DEFAULTS.limit)
+    .transform(
+      (n): LimitValue =>
+        LIMIT_SET.includes(n as LimitValue)
+          ? (n as LimitValue)
+          : n > LIMIT_SET[LIMIT_SET.length - 1]
+          ? LIMIT_SET[LIMIT_SET.length - 1]
+          : TRACK_QUERY_DEFAULTS.limit
+    )
+    .default(TRACK_QUERY_DEFAULTS.limit),
+
   sort: SortKeySchema.default(TRACK_QUERY_DEFAULTS.sort),
   order: z.enum(["asc", "desc"]).default(TRACK_QUERY_DEFAULTS.order),
+
   genre: z.string().default(""),
   artist: z.string().default(""),
   search: z.string().default(""),
 });
 
 export type TrackQueryParams = z.infer<typeof trackQuerySchema>;
-export type TrackQueryInput  = z.input<typeof trackQuerySchema>;
+export type TrackQueryInput = z.input<typeof trackQuerySchema>;
+
+/**
+ * Wide-typed defaults derived once
+ */
+export const SCHEMA_DEFAULT_QUERY: TrackQueryParams = trackQuerySchema.parse(
+  {}
+);

--- a/client/src/types/track.ts
+++ b/client/src/types/track.ts
@@ -16,13 +16,3 @@ export interface Meta {
   limit: number;
   totalPages: number;
 }
-
-export interface FetchTracksOptions {
-  page?: number;
-  limit?: number;
-  sort?: keyof Track;
-  order?: "asc" | "desc";
-  genre?: string;
-  artist?: string;
-  search?: string;
-}


### PR DESCRIPTION
### Changes

- add ts-belt and **Zod** validation stack;
- refactor useTracks, table & pagination to rely on URL state;
- introduce **trackQuerySchema** + constants:
  - `TRACK_QUERY_DEFAULTS`, `LIMIT_SET`, `LimitValue`;
- create **SCHEMA_DEFAULT_QUERY** (schema-derived defaults);
- new **useTrackQuery** hook (URL <=>validated query <=> patch);
- new pure helpers:
  -   `parseSearchParams()` – Option/Result wrapper;
  -   `buildSearchParams()` – serialise query, hide defaults;
- **TracksPage** to consume URL state via `patch`;
- validate `/tracks` API params with the same Zod schema;
- drop legacy FetchTracksOptions and local filter setters.

### Short discussion: keep A or switch to B?

What I did (Option A)
1. Use Option once to read the whole query object, then run it through Zod.
2. Same schema guards both the UI and the API call, so validation logic lives in one place.

*Why it’s technically correct*
1. Satisfies the task: filter values live in the URL, Option handles *maybe missing*, Zod enforces types.
2. Keeps UI props clean - components receive fully validated data or safe defaults.

*Could refactor to Option B*
1. Read each param with Option individually and default immediately, skipping Zod.
2. Simpler, less code, but I’ve already implemented Option A (do we even need Zod for the fetch in this option?)

I favour A for consistency with Zod-based API validation, but I can refactor to B